### PR TITLE
Remove unstable url for missing eigen version

### DIFF
--- a/tensorflow/contrib/cmake/external/eigen.cmake
+++ b/tensorflow/contrib/cmake/external/eigen.cmake
@@ -30,7 +30,7 @@ include (ExternalProject)
 # We parse the current Eigen version and archive hash from the bazel configuration
 file(STRINGS ${PROJECT_SOURCE_DIR}/../../workspace.bzl workspace_contents)
 foreach(line ${workspace_contents})
-    string(REGEX MATCH ".*\"(https://bitbucket.org/eigen/eigen/get/[^\"]*tar.gz)\"" has_url ${line})
+    string(REGEX MATCH ".*\"(http.*bitbucket.org/eigen/eigen/get/[^\"]*tar.gz)\"" has_url ${line})
     if(has_url)
         set(eigen_url ${CMAKE_MATCH_1})
         break()

--- a/tensorflow/contrib/makefile/download_dependencies.sh
+++ b/tensorflow/contrib/makefile/download_dependencies.sh
@@ -26,7 +26,7 @@ if [ ! -f $BZL_FILE_PATH ]; then
   exit 1;
 fi
 
-EIGEN_URL="$(grep -o 'http.*bitbucket.org/eigen/eigen/get/.*tar\.gz' "${BZL_FILE_PATH}" | grep -v mirror.bazel | head -n1)"
+EIGEN_URL="$(grep -o 'http.*bitbucket.org/eigen/eigen/get/.*tar\.gz' "${BZL_FILE_PATH}" | head -n1)"
 GEMMLOWP_URL="$(grep -o 'https://mirror.bazel.build/github.com/google/gemmlowp/.*zip' "${BZL_FILE_PATH}" | head -n1)"
 GOOGLETEST_URL="https://github.com/google/googletest/archive/release-1.8.0.tar.gz"
 NSYNC_URL="$(grep -o 'https://mirror.bazel.build/github.com/google/nsync/.*tar\.gz' "${BZL_FILE_PATH}" | head -n1)"

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -125,7 +125,6 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
         strip_prefix = "eigen-eigen-fd6845384b86",
         urls = [
             "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
-            "https://bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
         ],
     )
 


### PR DESCRIPTION
We can no longer pull this version of eigen from any repository. Use the
provided mirror all the time to pull down this wierd version.